### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :find_params, only: [:show, :edit, :update]
+  before_action :find_params, only: [:show, :edit, :update, :destroy]
   before_action :move_to_sign_in, only: [:new, :edit]
-  before_action :move_to_index, only: [:edit]
+  before_action :move_to_index, only: [:edit, :destroy]
 
   def index
     @items = Item.all.order('id  DESC')
@@ -32,6 +32,12 @@ class ItemsController < ApplicationController
     else
       render action: :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    return unless @item.destroy
+
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <% if current_user == @item.user %>
     <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path, data: {turbo_method: :delete}, class:"item-destroy" %>
 
     <% elsif user_signed_in? %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>


### PR DESCRIPTION
#what
商品削除機能を実装

#why
商品削除機能の実装のため

*ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
[https://gyazo.com/7f92f2a45b7b8a6bbbc2beae6bcd6a1b](url)